### PR TITLE
상태 판별 방법 수정

### DIFF
--- a/src/page/process_page.py
+++ b/src/page/process_page.py
@@ -72,12 +72,12 @@ class ProcessPage(tk.Frame):
 
         if not self.locker_state.is_door_open(self.CRRMngKey):
 
-            sqlDict = {'CRRMngKey': self.CRRMngKey,
-                       'USRMngKey': user_key, 'HashKey': hash_value, 'UseStat': 'U'}
-            sql.processDB(dict2Query('LCKLog', sqlDict))
-
             self.ratch.execute(self.sync_sensor, "O")
             sleep(2)
+
+        sqlDict = {'CRRMngKey': self.CRRMngKey,
+                   'USRMngKey': user_key, 'HashKey': hash_value, 'UseStat': 'U'}
+        sql.processDB(dict2Query('LCKLog', sqlDict))
 
         self.canvas.itemconfig(self.text_id, text="문이 열렸습니다. 물건을 넣어주세요")
 

--- a/src/page/process_page.py
+++ b/src/page/process_page.py
@@ -68,7 +68,14 @@ class ProcessPage(tk.Frame):
             MessageFrame(self.controller, "qr코드 생성에 실패하였습니다.")
             return
 
+        sql = SQL("root", "", "10.80.76.63", "SML")
+
         if not self.locker_state.is_door_open(self.CRRMngKey):
+
+            sqlDict = {'CRRMngKey': self.CRRMngKey,
+                       'USRMngKey': user_key, 'HashKey': hash_value, 'UseStat': 'U'}
+            sql.processDB(dict2Query('LCKLog', sqlDict))
+
             self.ratch.execute(self.sync_sensor, "O")
             sleep(2)
 
@@ -90,8 +97,6 @@ class ProcessPage(tk.Frame):
         self.ratch.execute(self.sync_sensor, "C")
         sleep(2)
 
-#         # 여기서부터 데이터베이스 저장 시작
-        sql = SQL("root", "", "10.80.76.63", "SML")
 
 #         # 저장하려는 함의 정보가 존재할 때
         if sql.processDB(f"SELECT * FROM LCKStat WHERE CRRMngKey='{self.CRRMngKey}';"):
@@ -152,6 +157,10 @@ QR코드를 카메라에 보여주게 되면 간편하게 열립니다.
         sql.processDB(
             f"UPDATE LCKStat SET UseStat='{LockerFrame.STATE_WAIT}' WHERE USRMngKey='{user_key}';"
         )
+        sqlDict = {'CRRMngKey': self.CRRMngKey,
+                   'USRMngKey': user_key, 'UseStat': 'W'}
+        sql.processDB(dict2Query('LCKLog', sqlDict))
+
         # 완료메시지 표시
         MessageFrame(self.controller, "완료되었습니다.")
 

--- a/src/page/setting_page.py
+++ b/src/page/setting_page.py
@@ -79,6 +79,9 @@ class SettingPage(tk.Frame):
         sql.processDB(
             f"UPDATE LCKStat SET UseStat='{LockerFrame.STATE_WAIT if current_state == LockerFrame.STATE_BROKEN else LockerFrame.STATE_BROKEN}' WHERE CRRMngKey='{CRRMngKey}';"
         )
+        sqlDict = {'CRRMngKey': CRRMngKey,
+                   'USRMngKey': 'admin', 'UseStat': 'F' if current_state == LockerFrame.STATE_BROKEN else LockerFrame.STATE_BROKEN}
+        sql.processDB(dict2Query('LCKLog', sqlDict))
         self.locker_frame.button_dict[locker_number].configure_color(
             fg_color="#1E8449" if current_state == LockerFrame.STATE_BROKEN else"#7C7877",
             hover_color="#2ECC71" if current_state == LockerFrame.STATE_BROKEN else"#7C7877")

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -21,7 +21,7 @@ class LockerState:
                 map(lambda x: x["CRRMngKey"], json_object["CRRInfo"]))
         self.locker_list = locker_list
 
-    def clac_threshold(self, CRRMngKey, sensorNmLis):
+    def calc_threshold(self, CRRMngKey, sensorNmLis):
         '''각 상태 판별을 위한 문턱값을 계산하여 반환합니다.
 
         Args:

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -75,7 +75,7 @@ class LockerState:
         """`CRRMngKey`의 함의 문 개폐 여부를 확인합니다.
         """
         try:
-            threshold = self.clac_threshold(CRRMngKey, ['LIG'])
+            threshold = self.calc_threshold(CRRMngKey, ['LIG'])
 
             if not threshold:
                 # 뭔가 문제가 있어 문턱값 못구함

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -103,7 +103,7 @@ class LockerState:
         """
         try:
 
-            threshold = self.clac_threshold(CRRMngKey, ['SSO', 'FSR'])
+            threshold = self.calc_threshold(CRRMngKey, ['SSO', 'FSR'])
 
             if not threshold:
                 # 뭔가 문제가 있어 문턱값 못구함

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -2,6 +2,7 @@ if __name__ == "__main__" or __name__ == "locker_state":
     from sql import SQL
 else:
     from .sql import SQL
+import numpy as np
 
 
 class LockerState:
@@ -20,20 +21,79 @@ class LockerState:
                 map(lambda x: x["CRRMngKey"], json_object["CRRInfo"]))
         self.locker_list = locker_list
 
+    def clac_threshold(self, CRRMngKey, sensorNmLis):
+        '''각 상태 판별을 위한 문턱값을 계산하여 반환합니다.
+
+        Args:
+            CRRMngKey (str): 문턱값을 구할 함 키.
+            sensorNmLis (list): 문턱값을 구하고자 하는 센서 이름. 'LIG','FSR',...
+
+        Return:
+            dict: 구하고자 하는 센서의 문턱값을 딕셔너리 형태로 반환 {센서명:문턱값}
+        '''
+        selectQuery = ''
+        resDict = {}
+
+        try:
+            firstUsedDate = self.sql.processDB(
+                f"SELECT AddDt FROM LCKLog WHERE CRRMngKey='{CRRMngKey}' AND UseStat = 'U' ORDER BY LCKLogKey DESC LIMIT 1;")
+            if not firstUsedDate:
+                # 사용 데이터가 없으면 초기 데이터라 판단 -> 그냥 최근 데이터 긁어와서 판단해도 괜찮을듯 -> 쿼리만 생성
+
+                selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' ORDER BY SenKey DESC LIMIT 20"
+            else:
+                aaa = self.sql.processDB(
+                    f"SELECT AddDt FROM LCKLog WHERE CRRMngKey='{CRRMngKey}' AND UseStat <> 'B' AND UseStat <> 'U' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY LCKLogKey DESC LIMIT 1;")
+                if not aaa:
+                    # 여기 진입했다는 뜻은 최근 첫 사용 데이터라 판단-> 첫 사용 데이터 이전의 값을 가져와 사용
+                    selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY SenKey DESC LIMIT 20"
+
+                else:
+                    selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' AND AddDt > '{aaa[0]['AddDt']}' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY SenKey DESC LIMIT 20"
+
+            if not selectQuery:
+                # 이론상 못들어오는곳
+                pass
+
+            sensorData = self.sql.processDB(selectQuery)
+
+            if not sensorData:
+                # 해당하는 센서값이 하나도 없는경우 -> 있을려나...? 나오면 뭔가 잘못된경우
+                pass
+            else:
+                for senNm in sensorNmLis:
+                    tmpLis = [d[senNm] for d in sensorData]
+                    resDict[senNm] = np.mean(tmpLis)
+
+        except Exception as e:
+            print(e)
+            return
+
+        return resDict
+
     def is_door_open(self, CRRMngKey):
         """`CRRMngKey`의 함의 문 개폐 여부를 확인합니다.
         """
         try:
+            threshold = self.clac_threshold(CRRMngKey, ['LIG'])
+
+            if not threshold:
+                # 뭔가 문제가 있어 문턱값 못구함
+                return
+
             data = self.sql.processDB(
-                f"SELECT LIG, HAL FROM SensorValue WHERE CRRMngKey='{CRRMngKey}' ORDER BY SenKey DESC LIMIT 1;")
+                f"SELECT HAL, LIG FROM SensorValue WHERE CRRMngKey='{CRRMngKey}' ORDER BY SenKey DESC LIMIT 1;")
             if not data:
                 return
+
+            if (data[0]['HAL'] == 0) or (np.abs(data[0]['LIG']-threshold['LIG']) < 20):
+                # 닫혀 있는 케이스
+                # 홀센서가 인식되어있으면 무조건 닫혀있는거
+                # 홀센서가 인식 안되어있더라도 광량이 변화가 없다고 판단되면 닫혀있다고 판단?
+                return False
             else:
-                data = data[0]
-                if data["HAL"] == 1:
-                    return True
-                else:
-                    return False
+                # 닫혀있지 않으면 열려있는걸로
+                return True
         except Exception as e:
             print(e)
             return
@@ -42,16 +102,23 @@ class LockerState:
         """`CRRMngKey`의 함 내부에 물건이 존재하는지 판별하는 함수입니다.
         """
         try:
+
+            threshold = self.clac_threshold(CRRMngKey, ['SSO', 'FSR'])
+
+            if not threshold:
+                # 뭔가 문제가 있어 문턱값 못구함
+                return
+
             data = self.sql.processDB(
                 f"SELECT SSO, FSR FROM SensorValue WHERE CRRMngKey='{CRRMngKey}' ORDER BY SenKey DESC LIMIT 1;")
             if not data:
                 return
+
+            if (threshold['SSO']-data[0]["SSO"]) > 5 or (data[0]["FSR"]-threshold['FSR']) > 10:
+                # 물건이 있을려면 압력이 증가하거나 초음파가 감소하는경우
+                return True
             else:
-                data = data[0]
-                if data["SSO"] < 25 or data["FSR"] > 200:
-                    return True
-                else:
-                    return False
+                return False
         except Exception as e:
             print(e)
             return

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -38,7 +38,7 @@ class LockerState:
             firstUsedDate = self.sql.processDB(
                 f"SELECT AddDt FROM LCKLog WHERE CRRMngKey='{CRRMngKey}' AND UseStat = 'U' ORDER BY LCKLogKey DESC LIMIT 1;")
             if not firstUsedDate:
-                # 사용 데이터가 없으면 초기 데이터라 판단 -> 그냥 최근 데이터 긁어와서 판단해도 괜찮을듯 -> 쿼리만 생성
+                # 사용 데이터가 없으면 초기 데이터라 판단 -> 그냥 최근 데이터 긁어와서 판단
 
                 selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' ORDER BY SenKey DESC LIMIT 20"
             else:

--- a/src/utils/locker_state.py
+++ b/src/utils/locker_state.py
@@ -35,25 +35,7 @@ class LockerState:
         resDict = {}
 
         try:
-            firstUsedDate = self.sql.processDB(
-                f"SELECT AddDt FROM LCKLog WHERE CRRMngKey='{CRRMngKey}' AND UseStat = 'U' ORDER BY LCKLogKey DESC LIMIT 1;")
-            if not firstUsedDate:
-                # 사용 데이터가 없으면 초기 데이터라 판단 -> 그냥 최근 데이터 긁어와서 판단
-
-                selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' ORDER BY SenKey DESC LIMIT 20"
-            else:
-                aaa = self.sql.processDB(
-                    f"SELECT AddDt FROM LCKLog WHERE CRRMngKey='{CRRMngKey}' AND UseStat <> 'B' AND UseStat <> 'U' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY LCKLogKey DESC LIMIT 1;")
-                if not aaa:
-                    # 여기 진입했다는 뜻은 최근 첫 사용 데이터라 판단-> 첫 사용 데이터 이전의 값을 가져와 사용
-                    selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY SenKey DESC LIMIT 20"
-
-                else:
-                    selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' AND AddDt > '{aaa[0]['AddDt']}' AND AddDt < '{firstUsedDate[0]['AddDt']}' ORDER BY SenKey DESC LIMIT 20"
-
-            if not selectQuery:
-                # 이론상 못들어오는곳
-                pass
+            selectQuery = f"SELECT {', '.join(sensorNmLis)} FROM SensorValue WHERE CRRMngKey = '{CRRMngKey}' ORDER BY SenKey ASC LIMIT 20"
 
             sensorData = self.sql.processDB(selectQuery)
 


### PR DESCRIPTION
## 구현 사항

- ~~데이터 베이스의 LCKLog의 사용내용을 기반으로 함이 Wait인 시간을 찾아 해당시간의 센서값의 평균을 문턱값으로 설정하여 상태를 판별하는데 사용~~
- 함 설치후 첫 기동후 20초간의 센싱값의 평균을 문턱값으로 사용하도록 수정

## 변경 사항

- 보관함에 보관, 찾기 할 때  LCKLog에 로그 기록하도록 수정
- 보관함 고장설정 할 때  LCKLog에 로그 기록하도록 수정

## LCKLog 상태값(UseStat) 정리

- W : Wait 대기중
- U : Used 사용중
- B : Broken 고장
- F :  Fixed 수리됨(고장 해제)


## 관련 이슈

- #40
