### PR TITLE
센서값 수신시 오류가 발생하여 thrading모듈 대신  multiprocessing 을 사용

### DIFF
--- a/src/utils/sensor_listener.py
+++ b/src/utils/sensor_listener.py
@@ -1,5 +1,5 @@
 import serial
-import threading
+from multiprocessing import *
 if __name__ == "__main__" or __name__ == "sensor_listener":
     from util import dict2Query, connect_arduino
     from sql import SQL
@@ -109,7 +109,7 @@ class SensorListener:
 
     def listen(self):
         for i in range(len(self.seri)):
-            t = threading.Thread(target=self.__listen_sensor, args=(
+            t = Process(target=self.__listen_sensor, args=(
                 self.seri[i], self.arduino_number[i]))
             t.start()
 


### PR DESCRIPTION

## 변경 사항

- 여러 아두이노를 통해 센서값 수신시 오류가 발생하여 thrading모듈 대신  multiprocessing 을 사용

## 상황 정리

- 현재로는 arduino mega 2560을 사용 중
- 아날로그 핀 갯수에 의해 아두이노 하나당 8개 함에 대한 센서 값 수신 가능
- 센서값 수신을 위한 SensorListener에서 쓰레드 생성시 2개까지는 문제 없음
- 3개째 부터 간헐적으로 센서값을 못받는 exception 발생
- 함이 16개(아두이노 2개로 커버가능한 최대 갯수) 초과시 센서값 수신용 라즈베리파이를 따로 둬야함
